### PR TITLE
Added explicit handling of Simo and Riflex executables

### DIFF
--- a/avm/avm.py
+++ b/avm/avm.py
@@ -58,7 +58,12 @@ def exe_path(appname, version=None, appverxml=None):
                            f"Version Manager.")
             return None
         else:
-            path = appversion.get('exepath')
+            if appname.lower() == 'simo':
+                path = f"{appversion.get('installdir')}simo\\bin\\rsimo.exe"
+            elif appname.lower() == 'riflex':
+                path = f"{appversion.get('installdir')}Riflex\\bin\\riflex.bat"
+            else:
+                path = appversion.get('exepath')
             versionnumber = appversion.get('versionnumber')
 
     else:
@@ -66,7 +71,12 @@ def exe_path(appname, version=None, appverxml=None):
         path, versionnumber = None, None
         for _, appversion in app.items():
             if appversion.get('default'):
-                path = appversion.get('exepath')
+                if appname.lower() == 'simo':
+                    path = f"{appversion.get('installdir')}simo\\bin\\rsimo.exe"
+                elif appname.lower() == 'riflex':
+                    path = f"{appversion.get('installdir')}Riflex\\bin\\riflex.bat"
+                else:
+                    path = appversion.get('exepath')
                 versionnumber = appversion.get('versionnumber')
 
         if path is None:
@@ -80,6 +90,7 @@ def exe_path(appname, version=None, appverxml=None):
         return None
     else:
         return f'"{path}"'
+
 
 
 def installation_path(appname, version=None, appverxml=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "avm"
-version = "1.0.2"
+version = "1.1.0"
 description = "Interact with DNV GL Software's Application Version Manager"
 authors = ["Per Voie, Sevan SSP <pev@sevanssp.com>"]
 license = "MIT"


### PR DESCRIPTION
Added explicit handling of Simo and Riflex executables as they are not automatically identified by avm. 'exe_path' now returns path to rsimo.exe for simo and riflex.bat for Riflex where it previously returned nothing. Other returns remain the same